### PR TITLE
Comment out category description

### DIFF
--- a/templates/pages/amp/category.html
+++ b/templates/pages/amp/category.html
@@ -27,8 +27,11 @@ category:
         <h1 class="categoryView-title">
             {{category.name}}
         </h1>
-        {{{category.description}}}
-        {{{snippet 'categories'}}}
+
+        {{!-- Category descriptions should include valid AMP markup. Read more about what are valid components: https://www.ampproject.org/docs/reference/components
+
+            {{{category.description}}}
+            {{{snippet 'categories'}}}  --}}
     </div>
     <main class="page-content" id="product-listing-container">
         {{#if category.products}}


### PR DESCRIPTION
Per Nathan's request, comment out the category description and snippet code so developers can enable if they would like to.

@mcampa 